### PR TITLE
Have underscores in identifier names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ stmt :=
      ident\[expr\] := expr
      expr
      ;.*
-     return expr
+     return [expr]
 
 expr :=
      true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ unaryop :=
     (bang is Boolean not)
 
 ident :=
-     [a-zA-Z][a-zA-Z0-9]*
+     [a-zA-Z_][a-zA-Z0-9_]*
 
 ```
 


### PR DESCRIPTION
Might be useful to designate special variable names or for readability purposes for some people.